### PR TITLE
Made self analysis check into its own separate middleware

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -50,7 +50,7 @@ taWidget.setupToken(app, serviceCredentials);
 
 app.get('/selfTwitterAnalysis', tw.toAnalysis, watsonHelpers.analyzeProfile);
 app.get('/twitter', tw.attachUsername, tw.toAuth);
-app.get('/twitter/return', tw.attachUsername, tw.fromAuth, tw.follow, tw.tweet);
+app.get('/twitter/return', tw.attachUsername, tw.fromAuth, tw.checkIfSelfAnalysis, tw.follow, tw.tweet);
 app.get('/twitterProfile/*', tw.testAnalysis);
 
 /****************/

--- a/server/social/twitter.js
+++ b/server/social/twitter.js
@@ -100,18 +100,14 @@ var renderTest = function(req, res) {
 };
 
 var follow = function(req, res, next) {
-  if (!req.params.username) {
-    res.redirect(301, '/selfTwitterAnalysis');
-  } else {
-    var params = {
-      screen_name: req.params.username
-    };
+  var params = {
+    screen_name: req.params.username
+  };
 
-    client.post('https://api.twitter.com/1.1/friendships/create.json', 
-      params, function(err) {
-        err ? res.status(500).send(err) : next();
-    });
-  }
+  client.post('https://api.twitter.com/1.1/friendships/create.json', 
+    params, function(err) {
+      err ? res.status(500).send(err) : next();
+  });
 };
 
 var tweet = function(req, res, par) {
@@ -138,6 +134,14 @@ var attachUsername = function(req, res, next) {
   next();
 }
 
+var checkIfSelfAnalysis = function(req, res, next) {
+  if (!req.params.username) {
+    res.redirect(301, '/selfTwitterAnalysis');
+  } else {
+    next();
+  }
+}
+
 module.exports = {
   toAuth: passport.authenticate('twitter'),
   fromAuth: passport.authenticate('twitter', { failureRedirect: '/'}),
@@ -148,4 +152,5 @@ module.exports = {
   follow: follow,
   tweet: tweet,
   attachUsername: attachUsername,
+  checkIfSelfAnalysis: checkIfSelfAnalysis
 }

--- a/server/social/twitter.js
+++ b/server/social/twitter.js
@@ -135,11 +135,7 @@ var attachUsername = function(req, res, next) {
 }
 
 var checkIfSelfAnalysis = function(req, res, next) {
-  if (!req.params.username) {
-    res.redirect(301, '/selfTwitterAnalysis');
-  } else {
-    next();
-  }
+  req.params.username ? next() : res.redirect(301, '/selfTwitterAnalysis');
 }
 
 module.exports = {

--- a/server/social/twitter.js
+++ b/server/social/twitter.js
@@ -139,8 +139,8 @@ var checkIfSelfAnalysis = function(req, res, next) {
 }
 
 module.exports = {
-  toAuth: passport.authenticate('twitter'),
-  fromAuth: passport.authenticate('twitter', { failureRedirect: '/'}),
+  toAuth: passport.authorize('twitter'),
+  fromAuth: passport.authorize('twitter', { failureRedirect: '/'}),
   analyzeProfile: analyzeProfile,
   testAnalysis: testAnalysis,
   toAnalysis: toAnalysis,


### PR DESCRIPTION
- moved redirect check for self analysis into its own function call
- changed twitter analyses passport helpers to use authorize instead of authenticate so logged in user object doesnt get overwritten